### PR TITLE
Fix 'Make sure we have the entry for hostname in /etc/hosts' task

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -27,7 +27,9 @@
   shell: echo -e "{{ kerberos_server_master_db_pass }}\n{{ kerberos_server_master_db_pass }}" | kdb5_util create -s; touch /var/kerberos/db_created creates=/var/kerberos/db_created
 
 - name: Make sure we have the entry for hostname in /etc/hosts
-  host: ip={{ ansible_default_ipv4.address }} hostname={{ ansible_hostname }} aliases="{{ ansible_hostname + '.' + kerberos_server_realm_name|lower() }}"
+  lineinfile: state=present dest=/etc/hosts
+              regexp='.*{{ ansible_default_ipv4.address  }}\s*{{ ansible_hostname  }}\s*{{ ansible_hostname  }}.{{ kerberos_server_realm_name|lower()  }}'
+              line='{{ ansible_default_ipv4.address  }} {{ ansible_hostname  }} {{ ansible_hostname  }}.{{ kerberos_server_realm_name|lower()  }}'
 
 - name: Start the kerberos services 
   service: name={{ item }} state=started enabled=yes

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -25,8 +25,10 @@
   script: create_db.sh {{ kerberos_server_master_db_pass }} 
   when: install.changed
 
-- name: Make sure we have the entry for hostname in /etc/hosts  
-  host: ip={{ ansible_default_ipv4.address }} hostname={{ ansible_hostname }} aliases="{{ ansible_hostname + '.' + kerberos_server_realm_name|lower() }}"
+- name: Make sure we have the entry for hostname in /etc/hosts
+  lineinfile: state=present dest=/etc/hosts
+              regexp='.*{{ ansible_default_ipv4.address }}\s*{{ ansible_hostname }}\s*{{ ansible_hostname }}.{{ kerberos_server_realm_name|lower() }}'
+              line='{{ ansible_default_ipv4.address }} {{ ansible_hostname }} {{ ansible_hostname }}.{{ kerberos_server_realm_name|lower() }}'
 
 - name: Start the kerberos services 
   service: name={{ item }} state=started enabled=yes


### PR DESCRIPTION
Trying to use the 'host' module in Ansible 2.0 yields to an error:
  no action detected in task. This often indicates a misspelled module name, or incorrect module path.

  The error appears to have been in erberos_server/tasks/ubuntu.yml': line 28, column 3, but may
  be elsewhere in the file depending on the exact syntax problem.

  The offending line appears to be:
     - name: Make sure we have the entry for hostname in /etc/hosts

This fix replaces the host module with lineinfile based solution to
include the hostname in /etc/hosts file
